### PR TITLE
fix: support nested .gitignore files in file watcher

### DIFF
--- a/src/server/utils/gitignore.ts
+++ b/src/server/utils/gitignore.ts
@@ -1,0 +1,116 @@
+/**
+ * Utilities for loading and parsing .gitignore files
+ */
+import ignore, { type Ignore } from 'ignore'
+import { readdir, readFile, stat } from 'node:fs/promises'
+import { dirname, join, relative, sep } from 'node:path'
+import type { FastifyBaseLogger } from 'fastify'
+
+/** Optional logger interface for warning about gitignore issues */
+type Logger = Pick<FastifyBaseLogger, 'warn'>
+
+/**
+ * Find all .gitignore files in a directory tree.
+ * Returns files sorted by path depth (root first) to ensure correct
+ * processing order for gitignore pattern precedence.
+ * Skips node_modules and .git directories for performance.
+ */
+export async function findGitignoreFiles (dir: string, log?: Logger): Promise<string[]> {
+  const gitignoreFiles: string[] = []
+  const dirsToWalk: string[] = [dir]
+  let dirIndex = 0
+
+  while (dirIndex < dirsToWalk.length) {
+    const currentDir = dirsToWalk[dirIndex++]
+    let entries: string[]
+    try {
+      entries = await readdir(currentDir)
+    } catch (err) {
+      log?.warn({ err, path: currentDir }, 'Failed to read directory while scanning for .gitignore files')
+      continue
+    }
+
+    for (const entry of entries) {
+      const fullPath = join(currentDir, entry)
+
+      // Skip .git and node_modules for performance
+      if (entry === '.git' || entry === 'node_modules') continue
+
+      if (entry === '.gitignore') {
+        gitignoreFiles.push(fullPath)
+        continue
+      }
+
+      try {
+        const stats = await stat(fullPath)
+        if (stats.isDirectory()) {
+          dirsToWalk.push(fullPath)
+        }
+      } catch {
+        // Skip entries we can't stat (common for broken symlinks)
+      }
+    }
+  }
+
+  // Sort by path depth (root .gitignore first) for correct precedence
+  return gitignoreFiles.sort((a, b) => {
+    const depthA = a.split(sep).length
+    const depthB = b.split(sep).length
+    return depthA - depthB
+  })
+}
+
+/**
+ * Load all .gitignore patterns from the repository, including nested ones.
+ * Patterns from nested .gitignore files are prefixed with their directory path
+ * so they apply correctly when matching against repo-relative paths.
+ */
+export async function loadGitignore (repoPath: string, log?: Logger): Promise<Ignore> {
+  const ig = ignore()
+  // Always ignore .git directory
+  ig.add('.git')
+
+  // Find all .gitignore files in the repo
+  const gitignoreFiles = await findGitignoreFiles(repoPath, log)
+
+  for (const gitignorePath of gitignoreFiles) {
+    let content: string
+    try {
+      content = await readFile(gitignorePath, 'utf-8')
+    } catch (err) {
+      log?.warn({ err, path: gitignorePath }, 'Failed to read .gitignore file')
+      continue
+    }
+
+    // Get relative path and normalize to forward slashes for gitignore patterns
+    const dirRelative = relative(repoPath, dirname(gitignorePath)).split(sep).join('/')
+
+    // Parse each line and prefix patterns from nested .gitignore files
+    const lines = content.split('\n')
+    for (const line of lines) {
+      const trimmed = line.trim()
+      // Skip empty lines and comments
+      if (!trimmed || trimmed.startsWith('#')) continue
+
+      if (dirRelative) {
+        // For nested .gitignore, prefix pattern with directory path
+        // Handle negation patterns (lines starting with !) and rooted patterns (starting with /)
+        const isNegation = trimmed.startsWith('!')
+        let pattern = isNegation ? trimmed.slice(1) : trimmed
+
+        // Remove leading slash - in nested .gitignore, patterns are relative to that directory
+        if (pattern.startsWith('/')) {
+          pattern = pattern.slice(1)
+        }
+
+        const prefixedPattern = `${dirRelative}/${pattern}`
+        ig.add(isNegation ? `!${prefixedPattern}` : prefixedPattern)
+      } else {
+        // Root .gitignore - add patterns as-is
+        ig.add(trimmed)
+      }
+    }
+  }
+
+  return ig
+}

--- a/tests/server/utils/gitignore.test.ts
+++ b/tests/server/utils/gitignore.test.ts
@@ -1,0 +1,135 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert'
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { findGitignoreFiles, loadGitignore } from '../../../src/server/utils/gitignore.ts'
+
+interface TestContext {
+  after: (fn: () => void) => void;
+}
+
+function createTempDir (t: TestContext): string {
+  const tempDir = mkdtempSync(join(tmpdir(), 'gitignore-test-'))
+  t.after(() => {
+    rmSync(tempDir, { recursive: true, force: true })
+  })
+  return tempDir
+}
+
+describe('gitignore utils', () => {
+  describe('findGitignoreFiles', () => {
+    it('should find root .gitignore', async (t) => {
+      const tempDir = createTempDir(t)
+      writeFileSync(join(tempDir, '.gitignore'), '*.log\n')
+
+      const files = await findGitignoreFiles(tempDir)
+
+      assert.strictEqual(files.length, 1)
+      assert.strictEqual(files[0], join(tempDir, '.gitignore'))
+    })
+
+    it('should find nested .gitignore files sorted by depth', async (t) => {
+      const tempDir = createTempDir(t)
+      mkdirSync(join(tempDir, 'src'))
+      mkdirSync(join(tempDir, 'src', 'deep'))
+
+      writeFileSync(join(tempDir, '.gitignore'), '*.log\n')
+      writeFileSync(join(tempDir, 'src', '.gitignore'), 'build/\n')
+      writeFileSync(join(tempDir, 'src', 'deep', '.gitignore'), 'temp/\n')
+
+      const files = await findGitignoreFiles(tempDir)
+
+      assert.strictEqual(files.length, 3)
+      // Should be sorted by depth (root first)
+      assert.ok(files[0].endsWith('.gitignore'))
+      assert.ok(!files[0].includes('src'))
+      assert.ok(files[1].includes('src'))
+      assert.ok(!files[1].includes('deep'))
+      assert.ok(files[2].includes('deep'))
+    })
+
+    it('should skip node_modules directory', async (t) => {
+      const tempDir = createTempDir(t)
+      mkdirSync(join(tempDir, 'node_modules'))
+
+      writeFileSync(join(tempDir, '.gitignore'), '*.log\n')
+      writeFileSync(join(tempDir, 'node_modules', '.gitignore'), 'should-be-skipped\n')
+
+      const files = await findGitignoreFiles(tempDir)
+
+      assert.strictEqual(files.length, 1)
+      assert.ok(!files[0].includes('node_modules'))
+    })
+  })
+
+  describe('loadGitignore', () => {
+    it('should always ignore .git directory', async (t) => {
+      const tempDir = createTempDir(t)
+
+      const ig = await loadGitignore(tempDir)
+
+      assert.strictEqual(ig.ignores('.git'), true)
+      assert.strictEqual(ig.ignores('.git/config'), true)
+    })
+
+    it('should load patterns from root .gitignore', async (t) => {
+      const tempDir = createTempDir(t)
+      writeFileSync(join(tempDir, '.gitignore'), '*.log\ndist/\n')
+
+      const ig = await loadGitignore(tempDir)
+
+      assert.strictEqual(ig.ignores('app.log'), true)
+      assert.strictEqual(ig.ignores('dist/bundle.js'), true)
+      assert.strictEqual(ig.ignores('src/app.ts'), false)
+    })
+
+    it('should prefix patterns from nested .gitignore', async (t) => {
+      const tempDir = createTempDir(t)
+      mkdirSync(join(tempDir, 'src'))
+
+      writeFileSync(join(tempDir, 'src', '.gitignore'), 'build/\n')
+
+      const ig = await loadGitignore(tempDir)
+
+      // Should ignore src/build/ but not root build/
+      assert.strictEqual(ig.ignores('src/build/output.js'), true)
+      assert.strictEqual(ig.ignores('build/output.js'), false)
+    })
+
+    it('should handle rooted patterns in nested .gitignore', async (t) => {
+      const tempDir = createTempDir(t)
+      mkdirSync(join(tempDir, 'src'))
+
+      // Leading slash should be stripped for nested .gitignore
+      writeFileSync(join(tempDir, 'src', '.gitignore'), '/build\n')
+
+      const ig = await loadGitignore(tempDir)
+
+      assert.strictEqual(ig.ignores('src/build'), true)
+    })
+
+    it('should handle negation patterns in nested .gitignore', async (t) => {
+      const tempDir = createTempDir(t)
+      mkdirSync(join(tempDir, 'src'))
+
+      writeFileSync(join(tempDir, '.gitignore'), '*.log\n')
+      writeFileSync(join(tempDir, 'src', '.gitignore'), '!important.log\n')
+
+      const ig = await loadGitignore(tempDir)
+
+      assert.strictEqual(ig.ignores('app.log'), true)
+      assert.strictEqual(ig.ignores('src/important.log'), false)
+    })
+
+    it('should skip comments and empty lines', async (t) => {
+      const tempDir = createTempDir(t)
+      writeFileSync(join(tempDir, '.gitignore'), '# This is a comment\n\n*.log\n')
+
+      const ig = await loadGitignore(tempDir)
+
+      assert.strictEqual(ig.ignores('app.log'), true)
+      assert.strictEqual(ig.ignores('# This is a comment'), false)
+    })
+  })
+})


### PR DESCRIPTION
   The file watcher previously only read the root .gitignore file,
   causing files ignored by nested .gitignore files to trigger
   unnecessary UI refresh events (making the UI unusable). 

   Changes:
   - Extract gitignore loading to src/server/utils/gitignore.ts
   - Recursively find all .gitignore files in the repo
   - Prefix nested patterns with their directory path
   - Handle rooted patterns (/) and negation patterns (!)
   - Sort by depth to ensure correct pattern precedence
   - Add optional logger for warning about unreadable files
   - Use async fs operations to avoid blocking the event loop
   - Use path.sep for cross-platform compatibility

   Tested against git check-ignore to verify correct behavior.