### PR TITLE
Issue #20: fix loading time in big repositories

### DIFF
--- a/src/server/routes/events.ts
+++ b/src/server/routes/events.ts
@@ -66,6 +66,7 @@ const eventsRoutes: FastifyPluginAsyncTypebox = async (fastify) => {
 
   // Set up file watcher for live updates
   let fileWatcher: FSWatcher | null = null
+  let closed = false
   const repoPath = fastify.config.repositoryPath
 
   // Debounced broadcast to avoid flooding on rapid file changes
@@ -81,6 +82,9 @@ const eventsRoutes: FastifyPluginAsyncTypebox = async (fastify) => {
     try {
       // Load gitignore patterns for filtering
       const ig = await loadGitignore(repoPath, fastify.log)
+
+      // Server may have shut down while we were scanning
+      if (closed) return
 
       fileWatcher = chokidar.watch(repoPath, {
         ignored: (filePath: string) => {
@@ -121,11 +125,15 @@ const eventsRoutes: FastifyPluginAsyncTypebox = async (fastify) => {
     }
   }
 
-  // Start watching immediately (could optimize to start only when clients connect)
-  await startWatching()
+  // Start watching in the background to avoid blocking plugin registration.
+  // On large repos, loadGitignore can exceed Fastify's default plugin timeout.
+  startWatching().catch((err) => {
+    fastify.log.warn({ err }, 'Unexpected error starting file watcher')
+  })
 
   // Clean up on server close
   fastify.addHook('onClose', async () => {
+    closed = true
     // Close all active SSE connections
     fastify.log.info({ clients: activeConnections.size }, 'Closing active SSE connections')
     for (const connection of activeConnections) {

--- a/src/server/utils/gitignore.ts
+++ b/src/server/utils/gitignore.ts
@@ -2,7 +2,7 @@
  * Utilities for loading and parsing .gitignore files
  */
 import ignore, { type Ignore } from 'ignore'
-import { readdir, readFile, stat } from 'node:fs/promises'
+import { readdir, readFile } from 'node:fs/promises'
 import { dirname, join, relative, sep } from 'node:path'
 import type { FastifyBaseLogger } from 'fastify'
 
@@ -22,33 +22,24 @@ export async function findGitignoreFiles (dir: string, log?: Logger): Promise<st
 
   while (dirIndex < dirsToWalk.length) {
     const currentDir = dirsToWalk[dirIndex++]
-    let entries: string[]
     try {
-      entries = await readdir(currentDir)
+      const entries = await readdir(currentDir, { withFileTypes: true })
+
+      for (const entry of entries) {
+        // Skip .git and node_modules for performance
+        if (entry.name === '.git' || entry.name === 'node_modules') continue
+
+        if (entry.name === '.gitignore') {
+          gitignoreFiles.push(join(currentDir, entry.name))
+          continue
+        }
+
+        if (entry.isDirectory()) {
+          dirsToWalk.push(join(currentDir, entry.name))
+        }
+      }
     } catch (err) {
       log?.warn({ err, path: currentDir }, 'Failed to read directory while scanning for .gitignore files')
-      continue
-    }
-
-    for (const entry of entries) {
-      const fullPath = join(currentDir, entry)
-
-      // Skip .git and node_modules for performance
-      if (entry === '.git' || entry === 'node_modules') continue
-
-      if (entry === '.gitignore') {
-        gitignoreFiles.push(fullPath)
-        continue
-      }
-
-      try {
-        const stats = await stat(fullPath)
-        if (stats.isDirectory()) {
-          dirsToWalk.push(fullPath)
-        }
-      } catch {
-        // Skip entries we can't stat (common for broken symlinks)
-      }
     }
   }
 


### PR DESCRIPTION
Fix serve startup timeout on large repositories

Defer file watcher initialization to run in the background instead of blocking Fastify plugin registration. On large repos, the recursive .gitignore scan in loadGitignore can exceed the default 10s plugin timeout, causing AVV_ERR_PLUGIN_EXEC_TIMEOUT.

Also optimize findGitignoreFiles to use readdir({ withFileTypes: true }),
eliminating a separate stat() syscall per directory entry.