### PR TITLE
Document resolved vs completed domain vocabulary

### DIFF
--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -25,6 +25,7 @@ export interface Comment {
   lineType: 'added' | 'removed' | 'context' | null;
   content: string;
   suggestion: string | null;
+  /** Whether the reviewer's concern has been addressed (the discussion is settled). */
   resolved: boolean;
   createdAt: string;
   updatedAt: string;
@@ -33,6 +34,7 @@ export interface Comment {
 export interface Todo {
   id: string;
   content: string;
+  /** Whether the work has been performed (the task is done). */
   completed: boolean;
   reviewId: string | null; // null for global todos
   position: number;


### PR DESCRIPTION
## Summary
- Add JSDoc comments to `Comment.resolved` and `Todo.completed` in `src/shared/types.ts`
- Documents the intentional semantic distinction: **resolved** means the reviewer's concern has been addressed (discussion settled), while **completed** means the work has been performed (task done)
- Prevents future contributors from "fixing" this perceived inconsistency

## Test plan
- [x] `npm run typecheck` passes — no type errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)